### PR TITLE
readme: update command to load topology and create volumes

### DIFF
--- a/standalone/README.md
+++ b/standalone/README.md
@@ -17,7 +17,7 @@ This vagrant-ansible script creates a setup for Heketi to manage GlusterFS.  It 
 ```
 $ <sudo for libvirt> vagrant ssh storage0
 $ export HEKETI_CLI_SERVER=http://localhost:8080
-$ heketi-cli load -json=topology_<provider>.json
+$ heketi-cli topology load --json=topology_<provider>.json
 ```
 
 Where _provider_ is either `virtualbox` or `libvirt` depending on the vagrant provider.
@@ -28,7 +28,7 @@ Heketi REST API has been created to be consumed by services like OpenStack Manil
 To create a 100GiB Replica 3 volume execute the following:
 
 ```
-$ heketi-cli volume create -size=100
+$ heketi-cli volume create --size=100
 ```
 
 # More information


### PR DESCRIPTION
I am starting to have a look at heketi for work, and I found two typos in the `standalone/README.md` file that I fixed
- use `heketi-cli topology load ...` rather than `heketi-cli load...`
- use `..create --size=100` rather than `...create -size=100`
