### PR TITLE
make sudo as true for sshexec

### DIFF
--- a/standalone/roles/heketi/files/heketi.json
+++ b/standalone/roles/heketi/files/heketi.json
@@ -27,8 +27,9 @@
 		"db" : "/var/lib/heketi/heketi.db",
 
 		"sshexec" : {
-            "keyfile" : "/etc/heketi/insecure_private_key",
-            "user" : "vagrant"
-        }
+			"keyfile" : "/etc/heketi/insecure_private_key",
+			"user" : "vagrant",
+			"sudo" : true
+		}
 	}
 }


### PR DESCRIPTION
When using vagrant as ssh user in heketi, we need to have the sudo flag
set as true; otherwise a command execution over ssh would not work.

Pair-programmed-with: Michael Adam obnox@samba.org
Signed-off-by: Raghavendra Talur rtalur@redhat.com
