### PR TITLE
replace sudo with become to remove ansible warning

### DIFF
--- a/standalone/site.yml
+++ b/standalone/site.yml
@@ -1,19 +1,19 @@
 - hosts: all
-  sudo: True
+  become: True
   roles:
     - common
 
 - hosts: client
-  sudo: True
+  become: True
   roles:
     - gluster_client
 
 - hosts: gluster
-  sudo: True
+  become: True
   roles:
     - gluster
 
 - hosts: heketi
-  sudo: True
+  become: True
   roles:
     - heketi


### PR DESCRIPTION
Ansible throws a deprecation warning when sudo module is used in
playbook. Replaced with become as recommended.

Signed-off-by: Raghavendra Talur rtalur@redhat.com
