### PR TITLE
Update openshift-ansible to release-1.3 branch

### DIFF
--- a/openshift/roles/client/tasks/main.yml
+++ b/openshift/roles/client/tasks/main.yml
@@ -11,9 +11,7 @@
     - bridge-utils 
     - bash-completion
     - dnsmasq
-
-- name: enable copr fedora heketi repo 
-  get_url: url=https://copr.fedorainfracloud.org/coprs/lpabon/Heketi/repo/epel-7/lpabon-Heketi-epel-7.repo dest=/etc/yum.repos.d/lpabon-Heketi-epel-7.repo mode=0644
+    - ncurses-term
 
 - name: install ansible and Heketi utilities
   yum: name={{ item }} state=present
@@ -23,8 +21,8 @@
     - heketi-client
     - heketi-templates
 
-- name: get openshift-ansible
-  git: repo=https://github.com/openshift/openshift-ansible dest=/home/vagrant/openshift-ansible version=enterprise-3.3
+- name: get openshift-ansible release 1.3
+  git: repo=https://github.com/openshift/openshift-ansible dest=/home/vagrant/openshift-ansible version=3cc5b0562de1b8a2334104542c15a6cce67b68bf
 
 - name: copy hosts.conf
   copy: src=hosts.conf dest=/home/vagrant force=yes mode=0644


### PR DESCRIPTION
It looks like the openshift-ansible branch enterprise-XX
no longer exists.  For that reason, we have changed to the
release-1.3 branch.  But instead of just using the branch
name, we are using the commit hash to _try_ to guarantee
that it will work for all.

Also updated to use EPEL release of Heketi instead of the
one from COPR.  Some users have complained that the
COPR repo times out.
