### PR TITLE
use epel instead of copr for standalone setup too

### DIFF
--- a/standalone/roles/heketi/tasks/main.yml
+++ b/standalone/roles/heketi/tasks/main.yml
@@ -1,6 +1,3 @@
-- name: enable copr fedora heketi repo 
-  get_url: url=https://copr.fedorainfracloud.org/coprs/lpabon/Heketi/repo/epel-7/lpabon-Heketi-epel-7.repo dest=/etc/yum.repos.d/lpabon-Heketi-epel-7.repo mode=0644
-
 - name: install ansible and Heketi utilities
   yum: name={{ item }} state=present
   with_items:


### PR DESCRIPTION
This one is for standalone. #21 already fixed the same for openshift
setups.

Closes #20
Signed-off-by: Raghavendra Talur rtalur@redhat.com
